### PR TITLE
Clarify Unicode terminology

### DIFF
--- a/npf-spec.md
+++ b/npf-spec.md
@@ -504,9 +504,9 @@ Is represented in NPF as:
 
 In addition to subtypes at the Text block level, the text within a Text block can have inline styles like bold, italic, external links, blog mentions, and colors.
 
-Inline formatting ranges (`start` and `end`) are zero-indexed and count each character as `1`. Ranges are inclusive at the start and exclusive at the end.
+Inline formatting ranges (`start` and `end`) are zero-indexed. Ranges are inclusive at the start and exclusive at the end.
 
-A single unicode character is also treated as one character in this indexing, despite possibly being multiple bytes. For example, `ø` and `🌳` are both counted as single characters in NPF. However, a composite emoji like `👨‍👨‍👦 `is five characters, as it is [made up of five unicode codepoints](http://emojipedia.org/family-man-man-boy/).
+Unicode code points are always treated as one character in this indexing, despite possibly being multiple bytes. For example, `ø` and `🌳` are both counted as single characters in NPF. However, a longer string like `👨‍👨‍👦 `is five characters, as it is [made up of five code points](http://emojipedia.org/family-man-man-boy/).
 
 Property | Type | Required | Description
 -------- | ---- | -------- | -----------


### PR DESCRIPTION
Unicode is complicated.

The [Unicode glossary](https://unicode.org/glossary/) gives four definitions for "character:"

1. The smallest component of written language that has semantic value; refers to the abstract meaning and/or shape, rather than a specific shape (see also *glyph*), though in code tables some form of visual representation is essential for the reader’s understanding.
2. Synonym for *abstract character*.
  * A unit of information used for the organization, control, or representation of textual data.
3. The basic unit of encoding for the Unicode character encoding.
4. The English name for the ideographic written elements of Chinese origin. [See *ideograph* (2).]

#1 and #4 are human concepts, not technical ones. #2 isn't clearly defined (hence the "abstract"). #3 is what's intended here, I believe, though clarification is helpful. This is why I changed it to "code point" ("Any value in the Unicode codespace; that is, the range of integers from 0 to 0x10FFFF"), which is consistent with other usages in the docs and seems to be what's intended.